### PR TITLE
Prevent constant NullPointerExceptions

### DIFF
--- a/src/com/kookykraftmc/af/AntiFake.java
+++ b/src/com/kookykraftmc/af/AntiFake.java
@@ -10,7 +10,7 @@ import java.util.List;
  */
 public class AntiFake extends JavaPlugin {
     //list of fake players
-    public List<String> FPs;
+    public List<String> FPs = new Vector<String>();
     //list of badblocks
     public List<String> BBs;
     //plugin description


### PR DESCRIPTION
- Initialise FPs so that we don't get NullPointerExceptions all the time
